### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -17,7 +17,7 @@ components:
         - name: ASPNETCORE_URLS
           value: http://*:8080
       endpoints:
-        - name: http-dotnet60
+        - name: https-dotnet60
           targetPort: 8080
           protocol: https
       volumeMounts:

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -19,6 +19,7 @@ components:
       endpoints:
         - name: http-dotnet60
           targetPort: 8080
+          protocol: https
       volumeMounts:
         - name: nuget
           path: /home/user/.nuget


### PR DESCRIPTION
chore: use https protocol in endpoint

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 12 21-11_22_20](https://github.com/che-samples/dotnet-web-simple/assets/1271546/4c9b16e9-07b6-4e63-9c01-114359ed48f5)

Related issue: https://issues.redhat.com/browse/CRW-5377